### PR TITLE
feat: add openshift s2i build as CI environment

### DIFF
--- a/packages/nx/src/utils/is-ci.ts
+++ b/packages/nx/src/utils/is-ci.ts
@@ -13,6 +13,7 @@ export function isCI() {
     process.env.BUILD_ID ||
     process.env.BUILD_BUILDID ||
     process.env.TEAMCITY_VERSION ||
-    process.env.TRAVIS === 'true'
+    process.env.TRAVIS === 'true' ||
+    process.env.STI_SCRIPTS_PATH
   );
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The NX scripts running on OpenShift S2I environment could assume current env is CI

The OpenShift S2I base image will include `STI_SCRIPTS_PATH `, which could be as a flag to detect if scripts is running within OpenShift Build
https://catalog.redhat.com/software/containers/rhel8/s2i-core/5ba0acc7d70cc57b0d1d9e64?container-tabs=dockerfile
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
